### PR TITLE
generic wifi access point support added

### DIFF
--- a/examples/WiFiPoint/WiFiPoint_ArduinoNano33IoT/WiFiPoint_ArduinoNano33IoT.pde
+++ b/examples/WiFiPoint/WiFiPoint_ArduinoNano33IoT/WiFiPoint_ArduinoNano33IoT.pde
@@ -1,0 +1,80 @@
+/*
+  RemoteXY example. 
+  Smartphone connect over Wi-Fi access point from Arduino Nano 33 IoT
+  (WiFiNINA module).
+
+  This shows an example of using the library RemoteXY.
+  In the example you can control the BUILTIN_LED using the button on the 
+  smartphone. The example uses the SPI and WiFiNINA library.
+  
+  Download the mobile app from the 
+  website: http://remotexy.com/download/ for connect this sketch.
+  
+  Use the website http://remotexy.com/ to create your own management 
+  interface your arduino with your smartphone or tablet.
+  You can create different management interfaces. Use buttons, 
+  switches, sliders, joysticks (g-sensor) all colors and sizes 
+  in its interface. Next, you will be able to get the sample 
+  code for arduino to use your interface for control from a 
+  smartphone or tablet. You will not need to re-install the 
+  android app, as it will determine which interface you have 
+  downloaded the arduino.
+  
+*/
+
+///////////////////////////////////////////// 
+//        RemoteXY include library         // 
+///////////////////////////////////////////// 
+
+/* RemoteXY select connection mode and include library */ 
+#include <SPI.h>      // SPI standard library
+#include <WiFiNINA.h> // WiFiNINA module library v1.8.7
+
+#define REMOTEXY_MODE__WIFI_POINT   	// data transfer using wifi and open server with access point
+//#define REMOTEXY__DEBUGLOGS Serial	// Enable RemoteXY debug message
+#include <RemoteXY.h>               	// RemoteXY library v2.4.6 (modified)
+
+/* RemoteXY connection settings */ 
+#define REMOTEXY_WIFI_SSID "RemoteXY" 
+#define REMOTEXY_WIFI_PASSWORD "12345678"
+#define REMOTEXY_SERVER_PORT 6377
+
+/* RemoteXY configurate  */ 
+unsigned char RemoteXY_CONF[] = 
+  { 1,0,11,0,1,5,1,0,21,2
+  ,59,59,2,88,0 }; 
+   
+/* this structure defines all the variables of your control interface */ 
+struct { 
+    /* input variable */
+  unsigned char button_1; /* =1 if button pressed, else =0 */
+
+    /* other variable */
+  unsigned char connect_flag;  /* =1 if wire connected, else =0 */
+
+} RemoteXY; 
+
+///////////////////////////////////////////// 
+//           END RemoteXY include          // 
+///////////////////////////////////////////// 
+
+
+void setup()  
+{ 
+  RemoteXY_Init ();  
+   
+  digitalWrite(LED_BUILTIN, LOW);	// init. built-in led off
+  pinMode(LED_BUILTIN, OUTPUT);	// conf. built-in led dout
+   
+  // TODO you setup code 
+} 
+
+void loop()  
+{  
+  RemoteXY_Handler (); 
+   
+  digitalWrite(LED_BUILTIN, (RemoteXY.button_1==0)?LOW:HIGH);
+   
+  // TODO you loop code 
+  // use the RemoteXY structure for data transfer 
+}

--- a/src/RemoteXY.h
+++ b/src/RemoteXY.h
@@ -24,6 +24,7 @@
     #define REMOTEXY_MODE__SOFTSERIAL_ESP8266_POINT   - data transfer via SOFTSERIAL using AT commands of ESP8266 and open access point with a server
     #define REMOTEXY_MODE__SOFTSERIAL_ESP8266_CLOUD   - data transfer via SOFTSERIAL using AT commands of ESP8266 and cloud connection
     #define REMOTEXY_MODE__WIFI                       - data transfer using wifi.h library and open server
+    #define REMOTEXY_MODE__WIFI_POINT                 - data transfer using wifi.h library and open server with access point
     
    Only ESP8266 boards:
     #define REMOTEXY_MODE__ESP8266CORE_ESP8266WIFI           - data transfer using <esp8266wifi.h> library and open server
@@ -129,6 +130,9 @@
   #define REMOTEXY_CLOUD
 #elif defined(REMOTEXY_MODE__WIFI) || defined(REMOTEXY_MODE__WIFI_LIB)
   #define REMOTEXY_MOD__WIFI
+#elif defined(REMOTEXY_MODE__WIFI_POINT)
+  #define REMOTEXY_MOD__WIFI
+  #define REMOTEXY_WIFI__POINT
 #elif defined(REMOTEXY_MODE__ESP8266CORE_ESP8266WIFI_POINT) || defined(REMOTEXY_MODE__ESP8266WIFI_LIB_POINT) || defined(REMOTEXY_MODE__ESP8266WIFIPOINT_LIB) 
   #define REMOTEXY_MOD__ESPCORE_WIFI
   #define REMOTEXY_WIFI__POINT

--- a/src/classes/RemoteXY_API.h
+++ b/src/classes/RemoteXY_API.h
@@ -275,7 +275,7 @@ class CRemoteXY_API {
         } 
         if (available!=0) {
           sendPackage (command, conf, confLength,  1);
-          *connect_flag = 1;
+          //*connect_flag = 1;
         }
         else {
           uint8_t buf[4];
@@ -320,6 +320,7 @@ class CRemoteXY_API {
     }  
     
     wireTimeOut=millis();    
+    *connect_flag = 1;
 #if defined(REMOTEXY_CLOUD)  
     if (cloudState==REMOTEXY_CLOUD_STATE_WORKING) {
       cloudTimeOut=millis();

--- a/src/modules/wifi.h
+++ b/src/modules/wifi.h
@@ -26,8 +26,23 @@ class CRemoteXY : public CRemoteXY_API {
   }
   
   uint8_t initModule () {  
-    delay(100);    
-    /* station only*/
+    delay(100);
+#if defined(REMOTEXY__DEBUGLOGS)
+    if (WiFi.status() == WL_NO_MODULE)  // check for WiFi module
+    	DEBUGLOGS_write("WiFi module err");
+#endif    
+#if defined(REMOTEXY_WIFI__POINT)	// access point mode
+    int stat;
+    stat = WiFi.beginAP(wifiSsid, wifiPassword);
+#if defined(REMOTEXY__DEBUGLOGS)
+    if (stat == WL_AP_LISTENING) {	// check for AP creation
+    	DEBUGLOGS_write("AP created");
+    	DEBUGLOGS_write("IP: 192.168.4.1");	// default local IP address: 192.168.4.1
+    }
+    else
+    	DEBUGLOGS_write("AP err");
+#endif
+#else					// station mode	
     WiFi.begin(wifiSsid, wifiPassword);
     uint8_t i = 40;
     while (WiFi.status() != WL_CONNECTED && i--) delay(500);
@@ -43,6 +58,7 @@ class CRemoteXY : public CRemoteXY_API {
     }
 #endif
     if (!i) return 0;
+#endif  
 
     client.stop();
     server = new WiFiServer (port);


### PR DESCRIPTION
WiFi access point mode was missing in current release (station mode only supported)
I've added it in the generic wifi.h file, so it can be used with many modules

before including RemoteXY repository, the remaining ecosystem must be added
for example:

```
#include <SPI.h>      // SPI standard library
#include <WiFiNINA.h> // WiFiNINA module library v1.8.7

#define REMOTEXY_MODE__WIFI_POINT // data transfer using wifi.h library and open server with access point
#define REMOTEXY__DEBUGLOGS Serial
#include <RemoteXY.h> // RemoteXY library v2.4.6 (modified)
```

I've tested it on Arduino Nano 33 IoT with WiFiNINA module