### PR TITLE
NimBLE support

### DIFF
--- a/examples/ESP32/BLE/NimBLE.pde
+++ b/examples/ESP32/BLE/NimBLE.pde
@@ -1,0 +1,89 @@
+/*
+   Simple button example
+   
+   This source code of graphical user interface 
+   has been generated automatically by RemoteXY editor.
+   To compile this code using RemoteXY library 3.1.1 or later version 
+   download by link http://remotexy.com/en/library/
+   To connect using RemoteXY mobile app by link http://remotexy.com/en/download/                   
+     - for ANDROID 4.5.1 or later version;
+     - for iOS 1.4.1 or later version;
+    
+   This source code is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.    
+*/
+
+//////////////////////////////////////////////
+//        RemoteXY include library          //
+//////////////////////////////////////////////
+
+// RemoteXY select connection mode and include library
+//#define REMOTEXY__DEBUGLOG 
+#define REMOTEXY_MODE__ESP32CORE_NIMBLE
+#include "NimBLEDevice.h" //Must include library h2zero/NimBLE-Arduino
+#include <RemoteXY.h>
+
+
+// RemoteXY configurate  
+#pragma pack(push, 1)
+uint8_t RemoteXY_CONF[] =
+  { 255,1,0,1,0,27,0,10,13,2,
+  1,0,9,9,46,46,6,7,50,50,
+  2,31,88,0,65,4,62,16,31,31,
+  14,62,35,35 };
+  
+// this structure defines all the variables and events of your control interface 
+struct {
+
+    // input variables
+  uint8_t button_1; // =1 if button pressed, else =0 
+
+    // output variables
+  uint8_t led_1_r; // =0..255 LED Red brightness 
+
+    // other variable
+  uint8_t connect_flag;  // =1 if wire connected, else =0 
+
+} RemoteXY;
+#pragma pack(pop)
+
+
+
+/////////////////////////////////////////////
+//           END RemoteXY include          //
+/////////////////////////////////////////////
+
+
+CRemoteXY *remotexy;
+
+void setup() 
+{
+  remotexy = new CRemoteXY (
+    RemoteXY_CONF_PROGMEM, 
+    &RemoteXY, 
+    "", 
+    new CRemoteXYStream_BLEDevice (
+      "myRemoteXY"       // REMOTEXY_BLUETOOTH_NAME
+    )
+  ); 
+  
+  
+  // TODO you setup code
+  
+}
+
+void loop() 
+{ 
+  remotexy->handler ();
+  
+  if (RemoteXY.button_1)  RemoteXY.led_1_r = 255;
+  else RemoteXY.led_1_r = 0;
+  
+  // TODO you loop code
+  // use the RemoteXY structure for data transfer
+  // do not call delay() 
+
+
+}

--- a/src/RemoteXY.h
+++ b/src/RemoteXY.h
@@ -42,6 +42,7 @@
     #define REMOTEXY_MODE__ESP32CORE_WIFI_POINT or REMOTEXY_MODE__WIFI_POINT      - data transfer using <wifi.h> library and open access point with a server
     #define REMOTEXY_MODE__ESP32CORE_WIFI_CLOUD or REMOTEXY_MODE__WIFI_CLOUD      - data transfer using <wifi.h> library and cloud connection
     #define REMOTEXY_MODE__ESP32CORE_BLE                     - data transfer using <BLEdevice.h> library
+    #define REMOTEXY_MODE__ESP32CORE_NIMBLE                   - data transfer using <NimBLEDevice.h> library
     #define REMOTEXY_MODE__ESP32CORE_BLUETOOTH               - data transfer using <BluetoothSerial.h> library
 
    Only NRF52xx based boards: 
@@ -136,7 +137,8 @@
   #include "BluetoothSerial.h"
 #elif defined(REMOTEXY_MODE__ESP32CORE_BLE)
   #include "BLEDevice.h"
-
+#elif defined(REMOTEXY_MODE__ESP32CORE_NIMBLE)
+  #include "NimBLEDevice.h"
 #endif
 
 
@@ -182,6 +184,10 @@
   #define RemoteXY_Init() remotexy = new CRemoteXY (RemoteXY_CONF_PROGMEM, &RemoteXY, REMOTEXY_ACCESS_PASSWORD, new CRemoteXYStream_AltSoftSerial (REMOTEXY_SERIAL_SPEED)) 
 
 #elif defined(REMOTEXY_MODE__ESP32CORE_BLE)
+  CRemoteXY *remotexy;   
+  #define RemoteXY_Init() remotexy = new CRemoteXY (RemoteXY_CONF_PROGMEM, &RemoteXY, REMOTEXY_ACCESS_PASSWORD, new CRemoteXYStream_BLEDevice (REMOTEXY_BLUETOOTH_NAME)) 
+
+#elif defined(REMOTEXY_MODE__ESP32CORE_NIMBLE)
   CRemoteXY *remotexy;   
   #define RemoteXY_Init() remotexy = new CRemoteXY (RemoteXY_CONF_PROGMEM, &RemoteXY, REMOTEXY_ACCESS_PASSWORD, new CRemoteXYStream_BLEDevice (REMOTEXY_BLUETOOTH_NAME)) 
 

--- a/src/RemoteXYStream_BLEDevice.h
+++ b/src/RemoteXYStream_BLEDevice.h
@@ -1,11 +1,12 @@
 #ifndef RemoteXYStream_BLEDevice_h
 #define RemoteXYStream_BLEDevice_h
 
-#if defined(MAIN_BLEDevice_H_)
+#if defined(MAIN_BLEDevice_H_) || defined(MAIN_NIMBLEDEVICE_H_)
 
 #include "RemoteXYComm.h"
+#ifdef MAIN_BLEDevice_H_
 #include <BLE2902.h>
-
+#endif
 
 #define REMOTEXYCOMM_BLEDEVICE__SEND_BUFFER_SIZE 20
 #define REMOTEXYCOMM_BLEDEVICE__RECEIVE_BUFFER_SIZE 1024
@@ -62,6 +63,17 @@ class CRemoteXYStream_BLEDevice : public CRemoteXYStream, BLEServerCallbacks, BL
     // Create the BLE Service
     BLEService *pService = pServer->createService(REMOTEXYCOMM_BLEDEVICE__SERVICE_UUID);
 
+#ifdef MAIN_NIMBLEDEVICE_H_
+  // Create a BLE Characteristic
+  pRxTxCharacteristic = pService->createCharacteristic(
+                            REMOTEXYCOMM_BLEDEVICE__CHARACTERISTIC_UUID_RXTX,
+                            NIMBLE_PROPERTY::READ |
+                            NIMBLE_PROPERTY::NOTIFY |
+                            NIMBLE_PROPERTY::WRITE_NR 
+                          );
+    
+#endif
+#ifdef MAIN_BLEDevice_H_
     // Create a BLE Characteristic
     pRxTxCharacteristic = pService->createCharacteristic(
                             REMOTEXYCOMM_BLEDEVICE__CHARACTERISTIC_UUID_RXTX,
@@ -70,9 +82,11 @@ class CRemoteXYStream_BLEDevice : public CRemoteXYStream, BLEServerCallbacks, BL
                             BLECharacteristic::PROPERTY_WRITE_NR 
                           );
 
+
     BLE2902 *ble2902 = new BLE2902();
     ble2902->setNotifications(true);
     pRxTxCharacteristic->addDescriptor(ble2902);
+#endif
     pRxTxCharacteristic->setCallbacks(this);
 
     // Start the service
@@ -180,5 +194,5 @@ class CRemoteXYStream_BLEDevice : public CRemoteXYStream, BLEServerCallbacks, BL
   
 };
 
-#endif // MAIN_BLEDevice_H_
+#endif // MAIN_BLEDevice_H_ || MAIN_NIMBLEDEVICE_H_
 #endif // RemoteXYStream_BLEDevice_h


### PR DESCRIPTION
Added Nimble Library support (https://github.com/h2zero/NimBLE-Arduino)
The library is a lot lighter than ESP32 BLE a lot less Flash used

Same simple code generated from UI (2 buttons and a label)

ESP32 BLE
RAM:  [=                   ]  11.7% (used 38276 bytes from 327680 bytes)
Flash: [========  ]  79.9% (used 1046925 bytes from 1310720 bytes)

ESP32 Nimble
RAM:  [=                  ]  10.7% (used 35120 bytes from 327680 bytes)
Flash: [====           ]  41.4% (used 542349 bytes from 1310720 bytes)
